### PR TITLE
Pre-fetch bioformats jars during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,12 @@ ENV PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:
 # Installing basicpy and other pip packages
 RUN pip --no-cache-dir install git+https://github.com/peng-lab/BaSiCpy@dev bioformats_jar
 
+# Pre-fetch bioformats jars to a world-readable location
+RUN python -c 'import bfio; bfio.start()' \
+    && mv /root/.jgo /root/.m2 /tmp \
+    && chmod -R a+rwX /tmp/.jgo /tmp/.m2
+ENV HOME=/tmp
+
 # Copy script and test run
 COPY ./main.py /opt/
 # RUN mkdir /data


### PR DESCRIPTION
Overrides $HOME as well to ensure scyjava/jgo will look in the right place for the cached .jgo directory even if the container is run under a user that doesn't exist in the container (and thus has no $HOME of its own).