### PR TITLE
Revert "Pre-fetch bioformats jars during docker build"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,6 @@ ENV PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:
 # Installing basicpy and other pip packages
 RUN pip --no-cache-dir install basicpy==1.2.0 bioformats_jar
 
-# Pre-fetch bioformats jars to a world-readable location
-RUN python -c 'import bfio; bfio.start()' \
-    && mv /root/.jgo /root/.m2 /tmp \
-    && chmod -R a+rwX /tmp/.jgo /tmp/.m2
-ENV HOME=/tmp
-
 # Copy script and test run
 COPY ./main.py /opt/
 # RUN mkdir /data


### PR DESCRIPTION
Reverts yfukai/basicpy-docker-mcmicro#21 for now, will include this whenever the build problem is solved.