### PR TITLE
Restore changes from #21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,14 @@ ENV PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:
 # Installing basicpy and other pip packages
 RUN pip --no-cache-dir install basicpy==1.2.0 bioformats_jar
 
+# Pre-fetch bioformats jars to a world-readable location.
+# Force TLS 1.2 to work around a Java bug in the JDK version in this container.
+RUN env JAVA_TOOL_OPTIONS='-Dhttps.protocols=TLSv1.2' \
+    python -c 'import bfio; bfio.start()' \
+    && mv /root/.jgo /root/.m2 /tmp \
+    && chmod -R a+rwX /tmp/.jgo /tmp/.m2
+ENV HOME=/tmp
+
 # Copy script and test run
 COPY ./main.py /opt/
 # RUN mkdir /data


### PR DESCRIPTION
The maven artifact fetch step introduced in #21 was intermittently failing due to a bug in Java's initial implementation of TLS 1.3. The relevant RUN line in the Dockerfile now forces Java to use TLS 1.2 which seems to fix the problem. Upgrading the base image's conda openjdk package to something much newer (or adding a RUN command to upgrade it here) should also fix the issue but that would be a bit more of an invasive change.