### PR TITLE
Set scikit-image minimum version to 0.21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:
 # Installing necessary packages
 
 # Installing basicpy and other pip packages
-RUN pip --no-cache-dir install basicpy==1.2.0 bioformats_jar
+RUN pip --no-cache-dir install basicpy==1.2.0 bioformats_jar 'scikit-image>=0.21.0'
 
 # Pre-fetch bioformats jars to a world-readable location.
 # Force TLS 1.2 to work around a Java bug in the JDK version in this container.


### PR DESCRIPTION
This avoids the problem introduced in 0.20.0 where the sample datasets are downloaded to a cache directory upon import of the top-level module. This causes an error when the container is being run as the calling user rather than root as the default cache directory is not writable. It is also a waste of time and network bandwidth as the datasets will never be used here.