### PR TITLE
Add optional parameter for flatfield and darkfield filenames

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ ENV PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:
 # Installing necessary packages
 
 # Installing basicpy and other pip packages
-RUN pip --no-cache-dir install basicpy==1.2.0 bioformats_jar 'scikit-image>=0.21.0'
+RUN pip --no-cache-dir install basicpy==1.2.0 bioformats_jar 'scikit-image>=0.21.0' 'hyperactive<5'
 
 # Pre-fetch bioformats jars to a world-readable location.
 # Force TLS 1.2 to work around a Java bug in the JDK version in this container.
 RUN env JAVA_TOOL_OPTIONS='-Dhttps.protocols=TLSv1.2' \
-    python -c 'import bfio; bfio.start()' \
+    python -c 'import bioformats_jar; bioformats_jar.get_loci()' \
     && mv /root/.jgo /root/.m2 /tmp \
     && chmod -R a+rwX /tmp/.jgo /tmp/.m2
 ENV HOME=/tmp

--- a/main.py
+++ b/main.py
@@ -159,12 +159,32 @@ def get_args():
         default=1e4,
         help="Relative weight of the l0 norm cost in the Fourier domain for autotuning.",
     )
+    optional.add_argument(
+    	"--output-flatfield",
+    	dest="output_flatfield",
+    	required=False,
+    	default=None,
+    	help="Filename for flatfield output. If empty will default to {input filename}. A sufix will be added to differenciate between flatfield and darkfield."
+    )
+    optional.add_argument(
+    	"--output-darkfield",
+    	dest="output_darkfield",
+    	required=False,
+    	default=None,
+    	help="Filename for darkfield output. If empty will default to {input filename}. A sufix will be added to differenciate between flatfield and darkfield."
+    )
 
     arg = parser.parse_args()
 
     # Convert input and output to Pathlib
     arg.input = Path(arg.input)
     arg.output_folder = Path(arg.output_folder)
+    
+    if arg.output_flatfield is None:
+    	arg.output_flatfield = splitext(args.input.name)[0]
+    	
+    if arg.output_darkfield is None:
+    	arg.output_darkfield = splitext(args.input.name)[0]
 
     return arg
 
@@ -254,8 +274,8 @@ def main(args):
     darkfields = np.moveaxis(np.array(darkfields), 0, -1)
 
     # Get output file names, splitext gets the file name without the extension
-    flatfield_path = args.output_folder / f"{splitext(args.input.name)[0]}-ffp.tiff"
-    darkfield_path = args.output_folder / f"{splitext(args.input.name)[0]}-dfp.tiff"
+    flatfield_path = args.output_folder / f"{args.output_flatfield}-ffp.tiff"
+    darkfield_path = args.output_folder / f"{args.output_darkfield}-dfp.tiff"
 
     # Save flatfields and darkfields
     imsave(flatfield_path, flatfields, check_contrast=False)
@@ -265,6 +285,8 @@ def main(args):
 if __name__ == "__main__":
     # Import arguments
     args = get_args()
+    
+    print(args)
 
     # Run main and check time
     main(args)

--- a/main.py
+++ b/main.py
@@ -160,18 +160,18 @@ def get_args():
         help="Relative weight of the l0 norm cost in the Fourier domain for autotuning.",
     )
     optional.add_argument(
-    	"--output-flatfield",
-    	dest="output_flatfield",
-    	required=False,
-    	default=None,
-    	help="Filename for flatfield output. If empty will default to {input filename}. A sufix will be added to differenciate between flatfield and darkfield."
+        "--output-flatfield",
+        dest="output_flatfield",
+        required=False,
+        default=None,
+        help="Filename for flatfield output. If empty will default to {input filename}. A sufix will be added to differenciate between flatfield and darkfield.",
     )
     optional.add_argument(
-    	"--output-darkfield",
-    	dest="output_darkfield",
-    	required=False,
-    	default=None,
-    	help="Filename for darkfield output. If empty will default to {input filename}. A sufix will be added to differenciate between flatfield and darkfield."
+        "--output-darkfield",
+        dest="output_darkfield",
+        required=False,
+        default=None,
+        help="Filename for darkfield output. If empty will default to {input filename}. A sufix will be added to differenciate between flatfield and darkfield.",
     )
 
     arg = parser.parse_args()
@@ -179,12 +179,12 @@ def get_args():
     # Convert input and output to Pathlib
     arg.input = Path(arg.input)
     arg.output_folder = Path(arg.output_folder)
-    
+
     if arg.output_flatfield is None:
-    	arg.output_flatfield = splitext(args.input.name)[0]
-    	
+        arg.output_flatfield = splitext(arg.input.name)[0]
+
     if arg.output_darkfield is None:
-    	arg.output_darkfield = splitext(args.input.name)[0]
+        arg.output_darkfield = splitext(arg.input.name)[0]
 
     return arg
 
@@ -285,8 +285,6 @@ def main(args):
 if __name__ == "__main__":
     # Import arguments
     args = get_args()
-    
-    print(args)
 
     # Run main and check time
     main(args)


### PR DESCRIPTION
This PR adds 2 optional command line options that act as the file name for the flatfield and darkfield output names.

Currently they share the inputs basename, but this adds more flexibility and works better for nextflow patterns.
It also remains backwards compatible if the parameters are not used.